### PR TITLE
Fix missing options file in the gemspec

### DIFF
--- a/routific.gemspec
+++ b/routific.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name              = 'routific'
-  s.version           = '1.1.0'
-  s.date              = '2016-04-16'
+  s.version           = '1.1.1'
+  s.date              = '2016-08-12'
   s.add_runtime_dependency('rest-client', '~> 1.7')
   s.add_runtime_dependency('json', '~> 1.8')
   s.add_development_dependency('rspec', '~> 3.0')
@@ -11,11 +11,8 @@ Gem::Specification.new do |s|
   s.description       = 'Gem to use Routific API'
   s.authors           = ['Marc Kuo', 'Andre Soesilo']
   s.email             = 'asoesilo@live.com'
-  s.files             = ['./lib/routific.rb', './lib/routific/location.rb',
-                          './lib/routific/route.rb', './lib/routific/vehicle.rb',
-                          './lib/routific/visit.rb', './lib/routific/way_point.rb']
+  s.files             = %w(README.md) + Dir["lib/**/*"]
   s.homepage          = 'https://routific.com/'
-  s.extra_rdoc_files  = ['README.md']
   s.license           = 'MIT'
   s.metadata    = { "source_code" => "https://github.com/asoesilo/routific-gem" }
 end


### PR DESCRIPTION
I realized that the newish options.rb file was not present in the `s.files` in the `gemspec`. Not entirely sure why this hasn't come up before, but was doing a reinstall of the gem and noticed the options file was not being pulled in. Hopefully a quick merge!