### PR TITLE
Upgrade runtime dependency json to 2.10

### DIFF
--- a/routific.gemspec
+++ b/routific.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version           = '1.7.3'
   s.date              = '2019-11-26'
   s.add_runtime_dependency('rest-client', '~> 2.0.1')
-  s.add_runtime_dependency('json', '~> 1.8')
+  s.add_runtime_dependency('json', '~> 2.3.0')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('faker', '>= 1.6.2')
   s.add_development_dependency('dotenv', '~> 0.11')


### PR DESCRIPTION
This addresses security vulnerability CVE-2020-10663 which is better described in
https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/